### PR TITLE
Fix debug builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -566,6 +566,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "bevy_editor_cam"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "493cf8fbcd67e0a335ec072c5946810747903a0c3202dce58dd0eda9df7a6680"
+dependencies = [
+ "bevy_app",
+ "bevy_asset",
+ "bevy_color",
+ "bevy_core_pipeline",
+ "bevy_derive",
+ "bevy_ecs",
+ "bevy_gizmos",
+ "bevy_image",
+ "bevy_input",
+ "bevy_log",
+ "bevy_math",
+ "bevy_picking",
+ "bevy_reflect",
+ "bevy_render",
+ "bevy_time",
+ "bevy_transform",
+ "bevy_utils",
+ "bevy_window",
+]
+
+[[package]]
 name = "bevy_encase_derive"
 version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1207,6 +1233,7 @@ version = "0.1.0"
 dependencies = [
  "async-channel",
  "bevy",
+ "bevy_editor_cam",
  "bevy_rapier3d",
  "bytemuck",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 license = "Apache-2.0 OR Custom"
 
 [dependencies]
-bevy = "0.15"
+bevy = { version = "0.15", features = ["shader_format_glsl"] }
 bytemuck = "1"
 async-channel = "2"
 futures = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,9 @@ wgsparkl3d = { git = "https://github.com/dimforge/wgsparkl.git", rev = "f64d3911
 parry3d = "0.18"
 bevy_rapier3d = "0.29"
 
+[dev-dependencies]
+bevy_editor_cam = "0.5"
+
 [patch.crates-io]
 # rapier3d = { path = "../rapier/crates/rapier3d" }
 # rapier3d = { path = "../rapier/crates/rapier3d" }

--- a/examples/cube.rs
+++ b/examples/cube.rs
@@ -78,7 +78,6 @@ pub fn setup_mpm_particles(
     let num_particles = grid_size_x * grid_size_y * grid_size_z;
 
     let particle_positions = (0..num_particles)
-        .into_iter()
         .map(|i| {
             let x = i % grid_size_x;
             let y = (i / grid_size_x) % grid_size_y;
@@ -142,7 +141,7 @@ pub fn setup_mpm_particles(
                     velocity: Vector3::zeros(),
                     volume: ParticleMassProps::new(density * volume, volume.cbrt() / 2.0),
                     model: ElasticCoefficients::from_young_modulus(
-                        100_000_000.0 * 10f32.powf((z - 1f32)),
+                        100_000_000.0 * 10f32.powf(z - 1f32),
                         0.2 + x * 0.05f32,
                     ),
                     plasticity: Some(DruckerPrager {
@@ -151,7 +150,7 @@ pub fn setup_mpm_particles(
                         h2: 1.6 + z * 0.5f32,
                         h3: 25.0f32.to_radians() + x,
                         ..DruckerPrager::new(
-                            100_000_000.0 * 10f32.powf((z - 1f32)),
+                            100_000_000.0 * 10f32.powf(z - 1f32),
                             0.2 + x * 0.05f32,
                         )
                     }),
@@ -178,8 +177,5 @@ pub fn setup_mpm_particles(
         cell_width,
         60_000,
     );
-    commands.insert_resource(PhysicsContext {
-        data,
-        particles: particles,
-    });
+    commands.insert_resource(PhysicsContext { data, particles });
 }

--- a/examples/cube.rs
+++ b/examples/cube.rs
@@ -1,5 +1,7 @@
 use bevy::prelude::*;
 use bevy::render::renderer::RenderDevice;
+use bevy_editor_cam::DefaultEditorCamPlugins;
+use bevy_editor_cam::prelude::EditorCam;
 use bevy_rapier3d::geometry::RapierColliderHandle;
 use bevy_rapier3d::plugin::ReadRapierContext;
 use bevy_rapier3d::prelude::{Collider, RigidBody};
@@ -9,6 +11,7 @@ use bevy_wgsparkl::resources::{AppState, PhysicsContext};
 use nalgebra::{Vector3, vector};
 use wgrapier3d::dynamics::body::{BodyCoupling, BodyCouplingEntry};
 use wgsparkl3d::models::DruckerPrager;
+use wgsparkl3d::solver::ParticlePhase;
 use wgsparkl3d::{
     models::ElasticCoefficients,
     pipeline::MpmData,
@@ -17,7 +20,7 @@ use wgsparkl3d::{
 
 pub fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugins((DefaultPlugins, DefaultEditorCamPlugins))
         .add_plugins(bevy_rapier3d::plugin::RapierPhysicsPlugin::<()>::default())
         .add_plugins(RapierDebugRenderPlugin::default())
         .add_plugins(bevy_wgsparkl::WgSparklPlugin)
@@ -28,6 +31,10 @@ pub fn main() {
 pub fn setup_scene(mut commands: Commands) {
     commands.spawn((
         Camera3d::default(),
+        EditorCam {
+            last_anchor_depth: 110f64,
+            ..Default::default()
+        },
         Transform::from_xyz(-30.0, 30.0, 100.0).looking_at(Vec3::new(0.0, 10.0, 0.0), Vec3::Y),
     ));
     /*
@@ -68,9 +75,9 @@ pub fn setup_mpm_particles(
     let grid_size_x = 25;
     let grid_size_y = 25;
     let grid_size_z = 25;
-    let num_rocks = grid_size_x * grid_size_y * grid_size_z;
+    let num_particles = grid_size_x * grid_size_y * grid_size_z;
 
-    let rocks = (0..num_rocks)
+    let particle_positions = (0..num_particles)
         .into_iter()
         .map(|i| {
             let x = i % grid_size_x;
@@ -103,7 +110,7 @@ pub fn setup_mpm_particles(
     let device = device.wgpu_device();
 
     if !app_state.restarting {
-        app_state.num_substeps = 32;
+        app_state.num_substeps = 16;
         app_state.gravity_factor = 1.0;
     };
 
@@ -115,27 +122,46 @@ pub fn setup_mpm_particles(
     let cell_width = 1.0;
     let mut particles = vec![];
 
-    for rock in &rocks {
-        let position = vector![rock.x, rock.y, rock.z];
+    for x in -1..2 {
+        for z in -1..2 {
+            let x = x as f32;
+            let z = z as f32;
+            let offset = vector![x * grid_size_x as f32, 0f32, z * grid_size_z as f32] * 2f32;
+            for particle in &particle_positions {
+                let position = vector![particle.x, particle.y, particle.z];
 
-        let rock_size = vector![1.0, 1.0, 1.0];
-        let volume = rock_size.x * rock_size.y * rock_size.z;
-        let density = 700.0;
-        particles.push(Particle {
-            position: vector![position.x, position.y, position.z],
-            velocity: Vector3::zeros(),
-            volume: ParticleMassProps::new(density * volume, volume.cbrt() / 2.0),
-            model: ElasticCoefficients::from_young_modulus(10_000_000.0, 0.2),
-            plasticity: Some(DruckerPrager {
-                // TODO: tune these values.
-                h0: 45.0f32.to_radians(),
-                h1: 50.0f32.to_radians(),
-                h2: 0.4,
-                h3: 15.0f32.to_radians(),
-                ..DruckerPrager::new(10_000_000.0, 0.2)
-            }),
-            phase: None,
-        });
+                let particle_size = vector![1.0, 1.0, 1.0];
+                let volume = particle_size.x * particle_size.y * particle_size.z;
+                let density = 1700.0;
+                particles.push(Particle {
+                    position: nalgebra::Rotation::from_axis_angle(
+                        &Vector3::z_axis(),
+                        5f32.to_radians(),
+                    ) * vector![position.x, position.y, position.z]
+                        + offset,
+                    velocity: Vector3::zeros(),
+                    volume: ParticleMassProps::new(density * volume, volume.cbrt() / 2.0),
+                    model: ElasticCoefficients::from_young_modulus(
+                        100_000_000.0 * 10f32.powf((z - 1f32)),
+                        0.2 + x * 0.05f32,
+                    ),
+                    plasticity: Some(DruckerPrager {
+                        h0: (45.0f32 + x * 20f32).to_radians(),
+                        h1: (70.0f32 + x * 20f32).to_radians() + z,
+                        h2: 1.6 + z * 0.5f32,
+                        h3: 25.0f32.to_radians() + x,
+                        ..DruckerPrager::new(
+                            100_000_000.0 * 10f32.powf((z - 1f32)),
+                            0.2 + x * 0.05f32,
+                        )
+                    }),
+                    phase: Some(ParticlePhase {
+                        phase: 0.5 + 0.5 * x,
+                        max_stretch: (0.0 + z).clamp(0.0, 1.0),
+                    }),
+                });
+            }
+        }
     }
 
     println!("Number of simulated particles: {}", particles.len());
@@ -152,5 +178,8 @@ pub fn setup_mpm_particles(
         cell_width,
         60_000,
     );
-    commands.insert_resource(PhysicsContext { data, particles });
+    commands.insert_resource(PhysicsContext {
+        data,
+        particles: particles,
+    });
 }

--- a/examples/cube.rs
+++ b/examples/cube.rs
@@ -110,7 +110,7 @@ pub fn setup_mpm_particles(
     let device = device.wgpu_device();
 
     if !app_state.restarting {
-        app_state.num_substeps = 16;
+        app_state.num_substeps = 8;
         app_state.gravity_factor = 1.0;
     };
 

--- a/examples/rocks.rs
+++ b/examples/rocks.rs
@@ -34,7 +34,7 @@ pub fn setup_scene(mut commands: Commands) {
      * Ground
      */
     let ground_size = 200.1;
-    let ground_height = 0.1;
+    let ground_height = 2.0;
 
     commands.spawn((
         Transform::from_xyz(0.0, -ground_height, 0.0),
@@ -112,7 +112,7 @@ pub fn setup_mpm_particles(
         dt: (1.0 / 60.0) / (app_state.num_substeps as f32),
     };
 
-    let cell_width = 0.5;
+    let cell_width = 1.0;
     let mut particles = vec![];
 
     for rock in &rocks {
@@ -120,7 +120,7 @@ pub fn setup_mpm_particles(
 
         let rock_size = vector![1.0, 1.0, 1.0];
         let volume = rock_size.x * rock_size.y * rock_size.z;
-        let density = 2700.0;
+        let density = 700.0;
         particles.push(Particle {
             position: vector![position.x, position.y, position.z],
             velocity: Vector3::zeros(),

--- a/src/instancing3d.rs
+++ b/src/instancing3d.rs
@@ -5,16 +5,17 @@ use bevy::{
     core_pipeline::core_3d::Transparent3d,
     ecs::{
         query::QueryItem,
-        system::{lifetimeless::*, SystemParamItem},
+        system::{SystemParamItem, lifetimeless::*},
     },
     pbr::{
         MeshPipeline, MeshPipelineKey, RenderMeshInstances, SetMeshBindGroup, SetMeshViewBindGroup,
     },
     prelude::*,
     render::{
+        Render, RenderApp, RenderSet,
         extract_component::{ExtractComponent, ExtractComponentPlugin},
         mesh::{
-            allocator::MeshAllocator, MeshVertexBufferLayoutRef, RenderMesh, RenderMeshBufferInfo,
+            MeshVertexBufferLayoutRef, RenderMesh, RenderMeshBufferInfo, allocator::MeshAllocator,
         },
         render_asset::RenderAssets,
         render_phase::{
@@ -23,7 +24,6 @@ use bevy::{
         },
         render_resource::*,
         view::ExtractedView,
-        Render, RenderApp, RenderSet,
     },
 };
 use bytemuck::{Pod, Zeroable};

--- a/src/prep_vertex_buffer.rs
+++ b/src/prep_vertex_buffer.rs
@@ -1,6 +1,6 @@
+use wgcore::Shader;
 use wgcore::kernel::{KernelInvocationBuilder, KernelInvocationQueue};
 use wgcore::tensor::GpuScalar;
-use wgcore::Shader;
 use wgebra::WgSvd2;
 use wgebra::WgSvd3;
 use wgpu::{Buffer, BufferUsages, ComputePipeline, Device};

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -48,7 +48,7 @@ pub fn setup_app(mut commands: Commands, device: Res<RenderDevice>) {
     let features = device.features();
     let timestamps = features
         .contains(Features::TIMESTAMP_QUERY)
-        .then(|| GpuTimestamps::new(device.wgpu_device(), 512));
+        .then(|| GpuTimestamps::new(device.wgpu_device(), 1024));
     commands.insert_resource(Timestamps {
         timestamps,
         ..Default::default()

--- a/src/step.rs
+++ b/src/step.rs
@@ -177,6 +177,8 @@ fn step_simulation_multisteps(
                 timestamps: Some(timestamps),
                 ..Default::default()
             };
+            // `GpuTimestamps` uses a buffer of 2 `Timestamps`, one for the start and one for the end of the operation,
+            // it's holding 9 floats (see `timings` below).
             debug_assert!(
                 timestamps_ms.len() >= num_substeps * 2 * 9,
                 "GpuTimestamps should be initialized with a bigger size"

--- a/src/step.rs
+++ b/src/step.rs
@@ -177,7 +177,10 @@ fn step_simulation_multisteps(
                 timestamps: Some(timestamps),
                 ..Default::default()
             };
-
+            debug_assert!(
+                timestamps_ms.len() >= num_substeps * 2 * 9,
+                "GpuTimestamps should be initialized with a bigger size"
+            );
             for i in 0..num_substeps {
                 let mut timings = [
                     &mut new_timings.grid_sort,
@@ -190,7 +193,8 @@ fn step_simulation_multisteps(
                     &mut new_timings.particles_update,
                     &mut new_timings.integrate_bodies,
                 ];
-                let times = &timestamps_ms[i * timings.len() * 2..];
+                let start_index = i * timings.len() * 2;
+                let times = &timestamps_ms[start_index..];
 
                 for (k, timing) in timings.iter_mut().enumerate() {
                     **timing += times[k * 2 + 1] - times[k * 2];


### PR DESCRIPTION
# Fix timestamp buffer not being big enough

This led to a use of unauthorized memory ; interestingly it's not caught on release, but it leads to a panic in debug.

# More...

Debug still crashes on pop os vulkan amd with:

```
thread 'Async Compute Task Pool (2)' panicked at /home/tb/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/naga-23.1.0/src/back/glsl/mod.rs:1206:17:
internal error: entered unreachable code
stack backtrace:
   0: rust_begin_unwind
             at /rustc/4d91de4e48198da2e33413efdcd9cd2cc0c46688/library/std/src/panicking.rs:692:5
   1: core::panicking::panic_fmt
             at /rustc/4d91de4e48198da2e33413efdcd9cd2cc0c46688/library/core/src/panicking.rs:75:14
   2: core::panicking::panic
             at /rustc/4d91de4e48198da2e33413efdcd9cd2cc0c46688/library/core/src/panicking.rs:145:5
   3: naga::back::glsl::Writer<W>::write_global
             at /home/tb/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/naga-23.1.0/src/back/glsl/mod.rs:1206:17
```

With a custom print local variable before the unreachable on naga-23.1.0/src/back/glsl/mod.rs:1206:17:

```
Unreachable reached while handling global constant with name: Some("diffuse_environment_mapsX_naga_oil_mod_XMJSXM6K7OBRHEOR2NVSXG2C7OZUWK527MJUW4ZDJNZTXGX")
```

<details><summary>(irrelevant?) info</summary>
<p>


Without full backtrace, it looks like this, but I think the unreachable was reached before that.

```
thread 'Async Compute Task Pool (1)' panicked at /home/tb/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/naga-23.1.0/src/back/glsl/mod.rs:1201:44:
internal error: entered unreachable code
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Encountered a panic in system `bevy_render::render_resource::pipeline_cache::PipelineCache::process_pipeline_queue_system`!

thread '<unnamed>' panicked at /home/tb/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/bevy_render-0.15.3/src/render_resource/pipeline_cache.rs:580:28:
index out of bounds: the len is 0 but the index is 4
Encountered a panic in system `bevy_render::renderer::render_system`!

thread 'main' panicked at /home/tb/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/wgpu-hal-23.0.1/src/vulkan/instance.rs:173:58:
Trying to destroy a SurfaceSemaphores that is still in use by a SurfaceTexture
```

</p>
</details> 
